### PR TITLE
Add david-dm dependency shields to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,8 @@
 ![](https://raw.githubusercontent.com/zeit/art/39a6d9ad77606e2589ddd620b23e093d3b3c6195/pkg/repo-banner.png)
 
 [![Build Status](https://travis-ci.org/zeit/pkg.svg?branch=master)](https://travis-ci.org/zeit/pkg)
+[![Dependency Status](https://david-dm.org/zeit/pkg/status.svg)](https://david-dm.org/zeit/pkg) 
+[![devDependency Status](https://david-dm.org/zeit/pkg/dev-status.svg)](https://david-dm.org/zeit/pkg?type=dev)
 [![Slack Channel](http://zeit-slackin.now.sh/badge.svg)](https://zeit.chat/)
 
 This command line interface enables you to package your Node.js project into an executable that can be run even on devices without Node.js installed.


### PR DESCRIPTION
See if repo dependencies are up-to-date at a glance. Also checks known security vunerabilities via [nodesecurity.io](https://nodesecurity.io).