### PR TITLE
Support for multiple -t arguments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -260,12 +260,11 @@ export async function exec (argv2) { // eslint-disable-line complexity
   // targets
 
   const sTargets = argv.t || argv.target || argv.targets || '';
-  if (typeof sTargets !== 'string') {
-    throw wasReported(`Something is wrong near ${JSON.stringify(sTargets)}`);
-  }
 
   let targets = parseTargets(
-    sTargets.split(',').filter((t) => t)
+    Array.isArray(sTargets)
+      ? sTargets
+      : sTargets.split(',').filter((t) => t)
   );
 
   if (!targets.length) {


### PR DESCRIPTION
Support multiple `-t` arguments which we discuss in #70. Im not sure if it should be in `--help`. I think string is preferred way.