### PR TITLE
add --bundledir param so that you can debug what files get bundled

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -16,6 +16,8 @@ export default function help () {
     -d, --debug      show more information during packaging process [off]
     -b, --build      don't download prebuilt base binaries, build them
     --public         speed up and disclose the sources of top-level project
+    --bundle-dir     copy files that'll go in snapshot into this directory
+                     mostly used for debugging what would be in the binary
 
   ${chalk.dim('Examples:')}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { exists, mkdirp, readFile, remove, stat, copy } from 'fs-extra';
+import { copy, exists, mkdirp, readFile, remove, stat } from 'fs-extra';
 import { log, wasReported } from './log.js';
 import { need, system } from 'pkg-fetch';
 import assert from 'assert';
@@ -122,9 +122,8 @@ export async function exec (argv2) { // eslint-disable-line complexity
   const argv = minimist(argv2, {
     boolean: [ 'b', 'build', 'bytecode', 'd', 'debug',
       'h', 'help', 'public', 'v', 'version' ],
-    string: [ '_', 'c', 'config', 'o', 'options', 'output',
-      'outdir', 'out-dir', 'out-path', 't', 'target', 'targets',
-      'bundledir', 'bundle-dir' ],
+    string: [ '_', 'bundledir', 'bundle-dir', 'c', 'config', 'o', 'options', 'output',
+      'outdir', 'out-dir', 'out-path', 't', 'target', 'targets' ],
     default: { bytecode: true }
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -440,8 +440,8 @@ export async function exec (argv2) { // eslint-disable-line complexity
         if (!fileStat || !fileStat.isFile()) {
           throw wasReported(`Failed to copy file ${source} to ${dest}`);
         }
-        copiedFileCount++;
-      } else if(!sourceStat.isDirectory()) {
+        copiedFileCount += 1;
+      } else if (!sourceStat.isDirectory()) {
         throw wasReported(`Unhandled source type for ${source}`);
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import { exists, mkdirp, readFile, remove, stat } from 'fs-extra';
+import { exists, mkdirp, readFile, remove, stat, copy } from 'fs-extra';
 import { log, wasReported } from './log.js';
 import { need, system } from 'pkg-fetch';
 import assert from 'assert';
@@ -121,7 +121,7 @@ async function needViaCache (target) {
 export async function exec (argv2) { // eslint-disable-line complexity
   const argv = minimist(argv2, {
     boolean: [ 'b', 'build', 'bytecode', 'd', 'debug',
-      'h', 'help', 'public', 'v', 'version' ],
+      'h', 'help', 'public', 'v', 'version', 'bundledir', 'bundle-dir' ],
     string: [ '_', 'c', 'config', 'o', 'options', 'output',
       'outdir', 'out-dir', 'out-path', 't', 'target', 'targets' ],
     default: { bytecode: true }
@@ -238,6 +238,11 @@ export async function exec (argv2) { // eslint-disable-line complexity
       configJson = { pkg: configJson };
     }
   }
+
+  // bundle dir
+  // Write bundle to dir if arg is set. This is typically only
+  // used for debugging what gets put into the built binary.
+  const bundleDir = argv.bundledir || argv['bundle-dir'];
 
   // output, outputPath
 
@@ -411,6 +416,37 @@ export async function exec (argv2) { // eslint-disable-line complexity
   const backpack = packer({ records, entrypoint, bytecode });
 
   log.debug('Targets:', JSON.stringify(targets, null, 2));
+
+  if (bundleDir) {
+    log.info(`Looking through ${Object.keys(records).length} sources to copy to ${bundleDir}`);
+    await remove(bundleDir);
+    let copiedFileCount = 0;
+    for (const fileKey of Object.keys(records)) {
+      const source = path.relative(process.cwd(), records[fileKey].file);
+      const dest = path.join(bundleDir, source);
+
+      if (!source) {
+        continue;
+      }
+
+      const sourceStat = await stat(source);
+
+      if (sourceStat.isFile()) {
+        log.debug(`copying ${source} to ${dest}`);
+        const destDir = path.dirname(dest);
+        await mkdirp(destDir);
+        await copy(source, dest);
+        const fileStat = await stat(dest);
+        if (!fileStat || !fileStat.isFile()) {
+          throw wasReported(`Failed to copy file ${source} to ${dest}`);
+        }
+        copiedFileCount++;
+      } else if(!sourceStat.isDirectory()) {
+        throw wasReported(`Unhandled source type for ${source}`);
+      }
+    }
+    log.info(`Copied ${copiedFileCount} files to ${bundleDir}`);
+  }
 
   for (const target of targets) {
     if (await exists(target.output)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -121,9 +121,10 @@ async function needViaCache (target) {
 export async function exec (argv2) { // eslint-disable-line complexity
   const argv = minimist(argv2, {
     boolean: [ 'b', 'build', 'bytecode', 'd', 'debug',
-      'h', 'help', 'public', 'v', 'version', 'bundledir', 'bundle-dir' ],
+      'h', 'help', 'public', 'v', 'version' ],
     string: [ '_', 'c', 'config', 'o', 'options', 'output',
-      'outdir', 'out-dir', 'out-path', 't', 'target', 'targets' ],
+      'outdir', 'out-dir', 'out-path', 't', 'target', 'targets',
+      'bundledir', 'bundle-dir' ],
     default: { bytecode: true }
   });
 


### PR DESCRIPTION
Sometimes you might want to debug (or export) the files that actually get put into the binary snapshot. This adds a flag to let you do just that.