### PR TITLE
Add permission flag to allow private modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,7 +121,7 @@ async function needViaCache (target) {
 export async function exec (argv2) { // eslint-disable-line complexity
   const argv = minimist(argv2, {
     boolean: [ 'b', 'build', 'bytecode', 'd', 'debug',
-      'h', 'help', 'public', 'v', 'version' ],
+      'h', 'help', 'public', 'v', 'version', 'permissive' ],
     string: [ '_', 'c', 'config', 'o', 'options', 'output',
       'outdir', 'out-dir', 'out-path', 't', 'target', 'targets' ],
     default: { bytecode: true }
@@ -393,6 +393,8 @@ export async function exec (argv2) { // eslint-disable-line complexity
   if (argv.public) {
     marker.config.license = 'public domain';
   }
+
+  marker.config.permissive = argv.permissive;
 
   // records
 

--- a/lib/walker.js
+++ b/lib/walker.js
@@ -22,7 +22,10 @@ function shortFromAlias (alias) {
 }
 
 function isPermissive (config) {
-  if (config.private) return false;
+  if (config.private) {
+      log.debug(`Module ${config.name} is marked as private`);
+      return false;
+  }
   let { license, licenses } = config;
   if (licenses) {
     license = licenses;
@@ -33,7 +36,10 @@ function isPermissive (config) {
   if (Array.isArray(license)) {
     license = license.map((c) => String(c.type || c)).join(',');
   }
-  if (!license) return false;
+  if (!license) {
+      log.debug(`Module ${config.name} does not have any license`);
+      return false;
+  }
   if (/^\(/.test(license)) license = license.slice(1);
   if (/\)$/.test(license)) license = license.slice(0, -1);
   license = license.toLowerCase();
@@ -50,6 +56,9 @@ function isPermissive (config) {
   for (const c of licenses) {
     result = foss.indexOf(c) >= 0;
     if (result) break;
+  }
+  if (!result) {
+      log.debug(`Module ${config.name} does not have a valid licence`);
   }
   return result;
 }
@@ -253,7 +262,7 @@ class Walker {
     }
 
     await this.appendFilesFromConfig(marker);
-    marker.permissive = isPermissive(config);
+    marker.permissive = this.permissive ? true : isPermissive(config);
     marker.activated = true;
     // assert no further work with config
     delete marker.config;
@@ -649,10 +658,15 @@ class Walker {
   async start (marker, entrypoint, addition) {
     marker.toplevel = true;
 
+    this.permissive = marker.config.permissive;
     this.tasks = [];
     this.records = {};
     this.dictionary = {};
     this.patches = {};
+
+    if (this.permissive) {
+      log.warn('Permissive flag enabled, about to ignore licenses in package.json');
+    }
 
     await this.readDictionary();
 

--- a/test/test-50-permissive-package-json/main.js
+++ b/test/test-50-permissive-package-json/main.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const assert = require('assert');
+const path = require('path');
 const utils = require('../utils.js');
 
 assert(!module.parent);
@@ -20,12 +21,10 @@ const inspect = (standard === 'stdout')
   : [ 'inherit', 'inherit', 'pipe' ];
 
 right = utils.pkg.sync([
-  '--debug',
+  '--permissive',
   '--target', target,
   '--output', output, input
 ], inspect);
-
-assert(right.indexOf('\x1B\x5B') < 0, 'colors detected');
 
 right = right.split('\n').filter(function (line) {
   return (line.indexOf(' [debug] ') >= 0) ||
@@ -41,26 +40,7 @@ right = right.split('\n').filter(function (line) {
 }).join('\n') + '\n';
 
 assert.equal(right,
-  '> [debug] Module undefined does not have any license\n' +
-  '> Warning Cannot resolve \'reqResSomeVar\'\n' +
-  '> [debug] Cannot resolve \'reqResSomeVarMay\'\n' +
-  '> Warning Malformed requirement for \'reqResSomeVar\'\n' +
-  '> Warning Malformed requirement for \'reqResSomeVar\'\n' +
-
-  '> Warning Cannot resolve \'reqSomeVar\'\n' +
-  '> [debug] Cannot resolve \'reqSomeVarMay\'\n' +
-  '> Warning Malformed requirement for \'reqSomeVar\'\n' +
-  '> Warning Malformed requirement for \'reqSomeVar\'\n' +
-
-  '> [debug] Cannot resolve \'tryReqResSomeVar\'\n' +
-  '> [debug] Cannot resolve \'tryReqResSomeVarMay\'\n' +
-  '> [debug] Cannot resolve \'tryReqSomeVar\'\n' +
-  '> [debug] Cannot resolve \'tryReqSomeVarMay\'\n' +
-
-  '> [debug] Cannot find module \'reqResSomeLit\'\n' +
-  '> [debug] Cannot find module \'reqResSomeLitMay\'\n' +
-  '> [debug] Cannot find module \'reqSomeLit\'\n' +
-  '> [debug] Cannot find module \'reqSomeLitMay\'\n'
-);
+  '> Warning Permissive flag enabled, about to ignore licenses in package.json\n' +
+  '> Warning Entry \'main\' not found in %1\n');
 
 utils.vacuum.sync(output);

--- a/test/test-50-permissive-package-json/main.js
+++ b/test/test-50-permissive-package-json/main.js
@@ -3,7 +3,6 @@
 'use strict';
 
 const assert = require('assert');
-const path = require('path');
 const utils = require('../utils.js');
 
 assert(!module.parent);

--- a/test/test-50-permissive-package-json/node_modules/crusader/package.json
+++ b/test/test-50-permissive-package-json/node_modules/crusader/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "crusader"
+}

--- a/test/test-50-permissive-package-json/test-x-index.js
+++ b/test/test-50-permissive-package-json/test-x-index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+require('crusader');


### PR DESCRIPTION
Add --permissive flag that allow private and unlicensed modules be
processed when using --no-bytecode flag.  For more information
please see zeit/pkg#145