### PR TITLE
Fix eslint on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "extends": "klopov",
     "parser": "babel-eslint",
     "rules": {
-      "wrap-iife": "off"
+      "wrap-iife": "off",
+      "linebreak-style": "off"
     }
   },
   "greenkeeper": {


### PR DESCRIPTION
This PR disables the `linebreak-style` eslint rule.