### PR TITLE
Prevent EACCESS errors due to file paths with leading slashes

### DIFF
--- a/lib/walker.js
+++ b/lib/walker.js
@@ -65,6 +65,9 @@ function upon (p, base) {
     p = p.slice(1);
     negate = true;
   }
+  if (p.startsWith('/')) {
+      p = p.substring(1);
+  }
   if (!path.isAbsolute(p)) {
     p = path.join(base, p);
   }


### PR DESCRIPTION
Some node modules contain paths within files with leading slashes. This causes EACCESS errors since pkg is not authorized to scan root directories. The fix here will remove the leading slash if it is present.
This fixes #528 and #524 