### PR TITLE
Added support for async generators

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "babel": {
     "plugins": [
       "transform-async-to-generator",
+      "transform-regenerator",
       "transform-runtime"
     ],
     "presets": [
@@ -48,6 +49,7 @@
     "babel-cli": "6.26.0",
     "babel-eslint": "10.0.1",
     "babel-plugin-transform-async-to-generator": "6.24.1",
+    "babel-plugin-transform-regenerator": "6.26.0",
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.7.0",
     "babel-register": "6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,7 +728,7 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-regenerator@^6.22.0:
+babel-plugin-transform-regenerator@6.26.0, babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
   integrity sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=


### PR DESCRIPTION
We need this to make [this](https://github.com/zeit/now-cli/pull/1710) work by adding support for async generators.