### PR TITLE
Fix pkg example express app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,13 @@
 
 # logs
 npm-debug.log
+
+# General macOS
+.DS_Store
+examples/.DS_Store
+
+# Example pkg'd application
+examples/express/express-example
+
+# Example dependencies
+examples/express/node_modules

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -10,7 +10,7 @@
       "views/**/*"
     ],
     "targets": [
-      "node10"
+      "node8"
     ]
   }
 }

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -10,7 +10,7 @@
       "views/**/*"
     ],
     "targets": [
-      "node7"
+      "node10"
     ]
   }
 }

--- a/examples/express/readme.md
+++ b/examples/express/readme.md
@@ -1,1 +1,15 @@
-Run `pkg .` here!
+# Express-Example
+
+> This example illustrates using `pkg` on a simple Express based app
+
+## Instructions
+
+  1. Run `npm install`
+  2. Run `pkg .`
+
+  That's it!
+
+## Post Success Notes
+
+  * Upon success, `pkg` will create an executable named "express-example". This file can be found at the root of the example project directory.
+  * To see the app in action, run the executable then navigate to http://localhost:8080/ in your browser.


### PR DESCRIPTION
**The Issue**
Currently, following the instructions provided in the `README` result in `pkg` failing to build the executable. The error output references `node7` as being an undefined `target` in `package.json`.

**The Solution**
`pkg` relies on `pkg-fetch` for retrieving Node versions to be used as `targets` in building executables. As of `pkg-fetch` v2.5, no `node` v7.x.x is listed as an available source. Changing `node7` to `node10` fixes this issue as it is available via `pkg-fetch` v2.5.

**Additionally, this PR**

- Adds files/folders to .gitignore related to the example express app which should not be included in master.
- Improves README ducumentation for example express app.