### PR TITLE
Update node-forge pkg scripts in dictionary

### DIFF
--- a/dictionary/node-forge.js
+++ b/dictionary/node-forge.js
@@ -3,7 +3,7 @@
 module.exports = {
   pkg: {
     scripts: [
-      'js/*.js'
+      'lib/*.js'
     ]
   }
 };


### PR DESCRIPTION
- Update node-forge pkg scripts in dictionary ("js" directory is now "lib" in node-forge package).
- Breaking change for those who are using old node-forge packages. Is there another way to do this?