### PR TITLE
feat: set codesign identity

### DIFF
--- a/lib/help.ts
+++ b/lib/help.ts
@@ -22,6 +22,7 @@ export default function help() {
     --no-native-build    skip native addons build
     --no-dict            comma-separated list of packages names to ignore dictionaries. Use --no-dict * to disable all dictionaries
     -C, --compress       [default=None] compression algorithm = Brotli or GZip
+    --codesign-identity  codesign identity to use for signing executables (default: "-" for ad-hoc signing)
 
   ${chalk.dim('Examples:')}
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -250,6 +250,7 @@ export async function exec(argv2: string[]) {
       'targets',
       'C',
       'compress',
+      'codesign-identity',
     ],
     default: { bytecode: true, 'native-build': true },
   });
@@ -690,7 +691,7 @@ export async function exec(argv2: string[]) {
         try {
           // sign executable ad-hoc to workaround the new mandatory signing requirement
           // users can always replace the signature if necessary
-          signMachOExecutable(target.output);
+          signMachOExecutable(target.output, argv["codesign-identity"]);
         } catch {
           if (target.arch === 'arm64') {
             log.warn('Unable to sign the macOS executable', [

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -691,7 +691,7 @@ export async function exec(argv2: string[]) {
         try {
           // sign executable ad-hoc to workaround the new mandatory signing requirement
           // users can always replace the signature if necessary
-          signMachOExecutable(target.output, argv["codesign-identity"]);
+          signMachOExecutable(target.output, argv['codesign-identity']);
         } catch {
           if (target.arch === 'arm64') {
             log.warn('Unable to sign the macOS executable', [

--- a/lib/mach-o.ts
+++ b/lib/mach-o.ts
@@ -59,7 +59,9 @@ function patchMachOExecutable(file: Buffer) {
 
 function signMachOExecutable(executable: string, identity?: string) {
   try {
-    execFileSync('codesign', ['--sign', identity || '-', executable], { stdio: 'inherit' });
+    execFileSync('codesign', ['--sign', identity || '-', executable], {
+      stdio: 'inherit',
+    });
   } catch {
     execFileSync('ldid', ['-Cadhoc', '-S', executable], { stdio: 'inherit' });
   }

--- a/lib/mach-o.ts
+++ b/lib/mach-o.ts
@@ -57,9 +57,9 @@ function patchMachOExecutable(file: Buffer) {
   return file;
 }
 
-function signMachOExecutable(executable: string) {
+function signMachOExecutable(executable: string, identity?: string) {
   try {
-    execFileSync('codesign', ['--sign', '-', executable], { stdio: 'inherit' });
+    execFileSync('codesign', ['--sign', identity || '-', executable], { stdio: 'inherit' });
   } catch {
     execFileSync('ldid', ['-Cadhoc', '-S', executable], { stdio: 'inherit' });
   }


### PR DESCRIPTION
Hi all,
thanks for this excellent package, I'm using it quite often.

This adds support for providing the macos codesign identity via a new `--codesign-identity` cli argument.

If there's anything which needs to be added / fixed, just tell me.