### PR TITLE
Do not remove temporary folder if it doesn't exist

### DIFF
--- a/prelude/bootstrap.js
+++ b/prelude/bootstrap.js
@@ -688,7 +688,7 @@ function payloadFileSync(pointer) {
   // ///////////////////////////////////////////////////////////////
 
   function removeTemporaryFolderAndContent(folder) {
-    if (!folder) return;
+    if (!folder || !fs.existsSync(folder)) return;
     if (NODE_VERSION_MAJOR <= 14) {
       if (NODE_VERSION_MAJOR <= 10) {
         // folder must be empty


### PR DESCRIPTION
When executing binaries created with pkg, I also occasionally encountered the error described in #1778, for example:

```
Error: ENOENT: no such file or directory, stat '/var/folders/q3/7_wg79yj5mg14320hlz4sqr00000gn/T/pkg-bnLwAL'
    at Object.statSync (node:fs:1596:3)
    at Object.statSync (pkg/prelude/bootstrap.js:1476:32)
    at __node_internal_ (node:internal/fs/utils:801:8)
    at Object.rmSync (node:fs:1271:13)
    at removeTemporaryFolderAndContent (pkg/prelude/bootstrap.js:704:10)
    at process.<anonymous> (pkg/prelude/bootstrap.js:711:5)
    at process.emit (node:events:549:35)
    at process.emit (node:domain:482:12)
```

Unfortunately irregular and not reproducible. I would therefore like to add this line so that the temporary folder is not deleted in the first place if it does not exist.